### PR TITLE
Configure vagrant to sync only the files and folders that are needed for deploying the web application

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,7 +11,11 @@ end
 
 Vagrant.configure("2") do |config|
   config.vagrant.plugins= ["vagrant-env"]
-  config.vm.synced_folder ".", "/vagrant", type: "rsync", rsync__exclude: [ ".env", ".env_template", ".git/", ".github/", ".gitignore", "CONTRIBUTORS.md", "LICENSE.md", "README.md", "pytest.ini", "tests/", "venv/", ".idea/", "Vagrantfile", "bootstrap-infra.py", "bootstrap.sh" ]
+  config.vm.synced_folder ".", "/vagrant", type: "rsync", disabled: true
+  config.vm.synced_folder "baboon/", "/vagrant/baboon/", type: "rsync"
+  config.vm.provision "file", source: "requirements.txt", destination: "/tmp/requirements.txt"
+  config.vm.provision "file", source: "app.py", destination: "/tmp/app.py"
+  config.vm.provision "shell", inline: "sudo cp /tmp/{requirements.txt,app.py}  /vagrant/"
   config.env.enable
 
   config.vm.provision "shell", path: "bootstrap.sh"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,11 +11,7 @@ end
 
 Vagrant.configure("2") do |config|
   config.vagrant.plugins= ["vagrant-env"]
-  config.vm.synced_folder ".", "/vagrant", type: "rsync", disabled: true
-  config.vm.synced_folder "baboon/", "/vagrant/baboon/", type: "rsync"
-  config.vm.provision "file", source: "requirements.txt", destination: "/tmp/requirements.txt"
-  config.vm.provision "file", source: "app.py", destination: "/tmp/app.py"
-  config.vm.provision "shell", inline: "sudo cp /tmp/{requirements.txt,app.py}  /vagrant/"
+  config.vm.synced_folder ".", "/vagrant", type: "rsync", rsync__exclude: [ "venv/", ".git/", ".idea/" ]
   config.env.enable
 
   config.vm.provision "shell", path: "bootstrap.sh"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,6 +11,7 @@ end
 
 Vagrant.configure("2") do |config|
   config.vagrant.plugins= ["vagrant-env"]
+  config.vm.synced_folder ".", "/vagrant", type: "rsync", rsync__exclude: [ ".env", ".env_template", ".git/", ".github/", ".gitignore", "CONTRIBUTORS.md", "LICENSE.md", "README.md", "pytest.ini", "tests/", "venv/", ".idea/", "Vagrantfile", "bootstrap-infra.py", "bootstrap.sh" ]
   config.env.enable
 
   config.vm.provision "shell", path: "bootstrap.sh"


### PR DESCRIPTION
FIx #136 
Configure vagrant to sync only the files and folders that are needed for deploying and bringing up the app application on the AWS instance.
Files and folders that are synced:
requirements.txt, app.py, baboon/

Files and folders that are not synced: 
.env, .env_template, .git/, .github/, .gitignore, CONTRIBUTORS.md, LICENSE.md, README.md, pytest.ini, tests/, venv/, .idea/, Vagrantfile, bootstrap-infra.py, bootstrap.sh

I tested the deployment with this liner(dev and stage), and the app was successfully up and accessible. 
